### PR TITLE
Made error #006 support the Hebrew character set, and re-enabled it for hewiki

### DIFF
--- a/checkwiki.pl
+++ b/checkwiki.pl
@@ -4810,7 +4810,6 @@ sub error_006_defaultsort_with_special_letters{
 		# {{ORDENA:Alfons I}}
 		if ( ($page_namespace == 0 or $page_namespace == 104)
 			and $project ne 'arwiki'
-			and $project ne 'hewiki'
 			and $project ne 'plwiki'
 			and $project ne 'jawiki'
 			and $project ne 'yiwiki'
@@ -4846,6 +4845,7 @@ sub error_006_defaultsort_with_special_letters{
 				$testtext =~ s/[ăîâşţ]//g   if ($project eq 'rowiki');
 				$testtext =~ s/[АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯабвгдежзийклмнопрстуфхцчшщьыъэюя]//g      if ($project eq 'ruwiki');
 				$testtext =~ s/[АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯабвгдежзийклмнопрстуфхцчшщьыъэюяіїґ]//g   if ($project eq 'ukwiki');
+        $testtext =~ s/[אבגדהוזחטיכךלמםנןסעפףצץקרשת]//g  if ($project eq 'hewiki'); # Hebrew has its own character set
 				$testtext =~ s/[~]//g  		if ($project eq 'huwiki');    # ~ for special letters
 				
 				#if ($testtext ne '') error_register(…);

--- a/checkwiki.pl
+++ b/checkwiki.pl
@@ -5820,7 +5820,6 @@ sub error_037_title_with_special_letters_and_no_defaultsort{
 			 and $category_counter > -1
 			 and $project ne 'arwiki'
 			 and $project ne 'jawiki'
-			 and $project ne 'hewiki'
 			 and $project ne 'plwiki'
 			 and $project ne 'trwiki'
 			 and $project ne 'yiwiki'
@@ -5865,6 +5864,7 @@ sub error_037_title_with_special_letters_and_no_defaultsort{
 				$testtext =~ s/[ÆØÅæøå]//g  if ($project eq 'nowiki');
 				$testtext =~ s/[ÆØÅæøå]//g  if ($project eq 'nnwiki');
 				$testtext =~ s/[ăîâşţ]//g   if ($project eq 'rowiki');
+        $testtext =~ s/[אבגדהוזחטיכךלמםנןסעפףצץקרשת]//g  if ($project eq 'hewiki'); # Hebrew has its own character set
 				$testtext =~ s/[АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯабвгдежзийклмнопрстуфхцчшщьыъэюя]//g   if ($project eq 'ruwiki');
 				$testtext =~ s/[АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯабвгдежзийклмнопрстуфхцчшщьыъэюяiїґ]//g   if ($project eq 'ukwiki');
 				


### PR DESCRIPTION
Hi.  Please merge this, so that checkwiki support checking error #6 (characters in DEFAULTSORT) in Hebrew as well.
