### PR TITLE
Update Foundation projects; fix issue with Wikipedia namespace.

### DIFF
--- a/checkwiki.pl
+++ b/checkwiki.pl
@@ -121,12 +121,12 @@ our @ErrorPriorityValue;    # Priority value each error has
 
 our @Error_number_counter = (0) x 150;    # Error counter for individual errors
 
-our @INTER_LIST = qw( af  als an  ar  bg  bs  ca  cs  cy  da  de
-  el  en  eo  es  et  eu  fa  fi  fr  fy  fl  gv
+our @INTER_LIST = qw( af  als an  ar  bg  bn  bs  ca  cs  cy  da  de
+  el  en  eo  es  et  eu  fa  fi  fr  fy
   he  hi  hr  hu  id  is  it  ja  jv  ka  ko
   la  lb  lt  ms  nds nl  nn  no  pl  pt  ro  ru
   sh  sk  sl  sr  sv  sw  ta  th  tr  uk  ur  vi
-  simple  nds_nl );
+  simple  nds_nl  zh );
 
 our @FOUNDATION_PROJECTS = qw( b  c  d  n  q  s  species  v  voy  wikt  m  mw
   meta        metawiki     metawikipedia  mediawikiwiki

--- a/checkwiki.pl
+++ b/checkwiki.pl
@@ -128,12 +128,14 @@ our @INTER_LIST = qw( af  als an  ar  bg  bs  ca  cs  cy  da  de
   sh  sk  sl  sr  sv  sw  ta  th  tr  uk  ur  vi
   simple  nds_nl );
 
-our @FOUNDATION_PROJECTS = qw( b  n  s  v  m  q  w  meta  mw  nost  wikt  wmf
-  bugzilla   commons     foundation incubator
-  meta-wiki  quality     speciesi   testwiki
-  wikibooks  wikidata    wikimedia  wikinews
-  wikiquote  wikipedia   wikisource wikispecies
-  wiktionary wikiversity wikivoyage );
+our @FOUNDATION_PROJECTS = qw( b  c  d  n  q  s  species  v  voy  wikt  m  mw
+  meta        metawiki     metawikipedia  mediawikiwiki
+  commons     wikibooks    wikidata       wikinews    
+  wikiquote   wikisource   wikispecies    wiktionary
+  wikivoyage  wikiversity  phabricator    wikitech
+  toollabs    testwiki     test2wiki      testwikidata
+  wmf         foundation   wikimedia      wmania
+  incubator   outreach );
 
 # See http://turner.faculty.swau.edu/webstuff/htmlsymbols.html
 our @HTML_NAMED_ENTITIES = qw( aacute Aacute acirc Acirc aelig AElig


### PR DESCRIPTION
Please, update the current Foundation projects.
There were also 2 typos: "speciesi" and "meta-wiki".
We probably don't need these:

`tools   bugzilla   mediazilla   quality   strategy   usability   
betawikiversity   oldwikisource   nost   nostalgia   tenwiki   donate`

If possible, do not add "w" and "wikipedia" until errors #68 and #82 are rewritten to take care of them, as explained here:

https://en.wikipedia.org/wiki/Wikipedia_talk:WikiProject_Check_Wikipedia#Error_82_confusion_and_new_error_104

For the same reason, "wikt" and "wiktionary" are special cases when the script is running for sv.wiktionary; and so on with other exceptions when running for commons, etc. At the moment, errors  #68 and #82 are not active in those projects, so my fix doesn't have effects on them.

As explained in the link above, "w" and "wikipedia" can also combine in multiple ways with language codes and with "m", "mw" and the like, with the script unable to sort out all the cases at the moment; see how the script works in es.wiki, where errors #68 and #82 have the majority of the problems (my fix doesn't solve all of them; for example it can't stop `[[:de:wikt:Kreis|kreis]]` showing up in error #68 instead of #82 ).
